### PR TITLE
Allow usage from file:// hosted origins

### DIFF
--- a/bitbox-bridge/src/web.rs
+++ b/bitbox-bridge/src/web.rs
@@ -46,7 +46,8 @@ fn is_valid_host(host: &str) -> bool {
     host == "localhost" || host == "127.0.0.1"
 }
 
-// Only accept websocket connections where the origin is "localhost" or from our domain
+// Only accept websocket connections where the origin is "localhost" or from our domain.
+// "null" is the origin when the origin is a file on the localhost, i.e., starts with file://.
 fn is_valid_origin(host: &str) -> bool {
     host == "localhost"
         || host == "127.0.0.1"
@@ -55,6 +56,7 @@ fn is_valid_origin(host: &str) -> bool {
         || host == "digitalbitbox.com"
         || host.ends_with(".myetherwallet.com")
         || host == "myetherwallet.com"
+        || host == "null"
 }
 
 fn add_origin(


### PR DESCRIPTION
Fixes #7

I don't fully understand the drawbacks of allowing "null". We might not want to merge this PR.

There is a [note on MDN](https://w3c.github.io/webappsec-cors-for-developers/#avoid-returning-access-control-allow-origin-null):

> Note: null should not be used: "It may seem safe to return Access-Control-Allow-Origin: "null", but the serialization of the Origin of any resource that uses a non-hierarchical scheme (such as data: or file:) and sandboxed documents is defined to be "null". Many User Agents will grant such documents access to a response with an Access-Control-Allow-Origin: "null" header, and any origin can create a hostile document with a "null" Origin. The "null" value for the ACAO header should therefore be avoided."