### PR TITLE
Added pocketbitcoin.com to whitelisted hosts

### DIFF
--- a/bitbox-bridge/src/web.rs
+++ b/bitbox-bridge/src/web.rs
@@ -55,6 +55,8 @@ fn is_valid_origin(host: &str) -> bool {
         || host == "digitalbitbox.com"
         || host.ends_with(".myetherwallet.com")
         || host == "myetherwallet.com"
+        || host.ends_with(".pocketbitcoin.com")
+        || host == "pocketbitcoin.com"
 }
 
 fn add_origin(


### PR DESCRIPTION
Hi everyone
In the future we would like to access the bitbox-bridge from our web application hosted on pocketbitcoin.com. Thank you very much in advance for white listing our domain.
Best regards
Tobi