### PR TITLE
release/darwin: add entitlements for code signing

### DIFF
--- a/bitbox-bridge/release/darwin/entitlements.plist
+++ b/bitbox-bridge/release/darwin/entitlements.plist
@@ -1,0 +1,15 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+    <!-- We listen on network ports -->
+    <key>com.apple.security.network.server</key>
+    <true/>
+    <!-- We respond on network ports -->
+    <key>com.apple.security.network.client</key>
+    <true/>
+    <!-- We communicate with usb devices -->
+    <key>com.apple.security.device.usb</key>
+    <true/>
+</dict>
+</plist>


### PR DESCRIPTION
The entitlements file is required for the codesign tool to sign
bitbox-bridge binary. The signing workflow looks something like this:

Sign the universal binary:

    codesign -f --timestamp --strict -o runtime \
      --entitlements entitlements.plist \
      -s <app-cert-identity> \
      bin/bitbox-bridge

Produce the pkg installer with an extra --sign flag to productbuild:

    productbuild --distribution ... \
      --sign <installer-cert-identity> \
      macos-installer.pkg

Submit the pkg for notarization:

    xcrun altool --notarize-app \
      --primary-bundle-id ch.shiftcrypto.bitboxbridge \
      --username user@example.org \
      --file macos-installer.pkg

Once notarized, staple the ticket onto the installer pkg for offline
   distribution:

    xcrun stapler staple macos-installer.pkg

I have a script that does all of the above but it needs a bit more
work. With this commit, I just want to release v1.3.0. Will add the
scripts afterwards.

This is a replacement of https://github.com/digitalbitbox/bitbox-bridge/pull/26 with app-sandbox removed and more details on how this works in the commit msg. See full thread in https://github.com/digitalbitbox/bitbox-bridge/pull/26#discussion_r616465637.