### PR TITLE
allow all Chrome and Firefox extensions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## 1.4.0
+
+- Whitelist Chrome and Firefox extensions
+
 ## 1.3.1
 
 - Fix a bug where the bridge crashes if a connected USB devices contains unicode in the HID device info

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -86,7 +86,7 @@ checksum = "b41b7ea54a0c9d92199de89e20e58d49f02f8e699814ef3fdf266f6f748d15c7"
 
 [[package]]
 name = "bitbox-bridge"
-version = "1.3.1"
+version = "1.4.0"
 dependencies = [
  "byteorder",
  "clap",

--- a/bitbox-bridge/Cargo.toml
+++ b/bitbox-bridge/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "bitbox-bridge"
-version = "1.3.1"
+version = "1.4.0"
 authors = ["Niklas Claesson <nicke.claesson@gmail.com>"]
 edition = "2018"
 license = "Apache-2.0"

--- a/bitbox-bridge/release/windows/wix/Product.wxs
+++ b/bitbox-bridge/release/windows/wix/Product.wxs
@@ -2,7 +2,7 @@
 <Wix xmlns="http://schemas.microsoft.com/wix/2006/wi">
 
   <!-- ProductCode should change with every release -->
-  <?define ProductCode = "{f75f2097-6bad-4bd5-b6d7-352c048df6ae}"?>
+  <?define ProductCode = "{ddf4b648-48b7-4855-9945-6e9e81c4951b}"?>
   <!-- UpgradeCode should stay the same foverever (this is the real ID of the app)-->
   <?define UpgradeCode = "{dfe7eecb-5dc0-4c30-ba78-a9eff36efa31}"?>
 

--- a/bitbox-bridge/src/web.rs
+++ b/bitbox-bridge/src/web.rs
@@ -200,9 +200,15 @@ pub fn create(
     // Use untuple_one at the end to get rid of the "unit" return value
     let check_origin = warp::header::optional("origin")
         .and_then(|origin: Option<hyper::Uri>| {
-            debug!("{:?}", origin);
+            debug!("Origin: {:?}", origin);
             async move {
                 if let Some(origin) = origin {
+                    let scheme_str = origin.scheme_str();
+                    if scheme_str == Some("chrome-extension") || scheme_str == Some("moz-extension")
+                    {
+                        debug!("Allow Chrome/Firefox extension");
+                        return Ok(());
+                    }
                     match origin.host() {
                         Some(host) => {
                             if !is_valid_origin(host) {


### PR DESCRIPTION
It is possible to whitelist specific extensions by ID, but since
adding extensions is manual, we can skip this. The main reason to skip
it is so that development builds of extensions (e.g. Metamask) can
connect to the BitBox02.