### PR TITLE
update hidapi to 2.3.2

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -612,8 +612,9 @@ dependencies = [
 
 [[package]]
 name = "hidapi"
-version = "2.3.1"
-source = "git+https://github.com/benma/hidapi-rs.git?branch=update-hidapi#2daa7b7d782c6611ffd2fac036f76e6010be26ae"
+version = "2.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "88c57421a3f575970573c2d8bedcaf4c9fe1a560c6944651c7256d408ee091b1"
 dependencies = [
  "cc",
  "libc",

--- a/hidapi-async/Cargo.toml
+++ b/hidapi-async/Cargo.toml
@@ -12,7 +12,6 @@ repository = "https://github.com/digitalbitbox/bitbox-bridge"
 [dependencies]
 futures = "0.3.1"
 log = "0.4.8"
-# Can be switched back to upstream once https://github.com/ruabmbua/hidapi-rs/issues/115 is fixed.
-hidapi = { git ="https://github.com/benma/hidapi-rs.git", branch="update-hidapi" }
+hidapi = "2.3.2"
 async-std = "1.2.0"
 thiserror = "1.0.9"


### PR DESCRIPTION
Going back to upstream after it merged the branch `update-hidapi` we used since b60e027a612775b5501539755b546c5fb42eeb0a.