### PR TITLE
add Windows to 1.5.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## 1.5.1
 - Fix bug where on macOS 13.3, the bridge would register one BitBox02 twice
+- Fix a bug on Windows 11 causing timeouts of BitBox02 workflows
 - Release built using the `shiftcrypto/bitbox-bridge:1` Docker image
 
 ## 1.5.0


### PR DESCRIPTION
Some Rabby users experiences timeouts during BitBox02 workflows such
as aborted transaction signing or aborted pairing code confirmation,
with the "Unexpected NACK" error. This indicated that the
communication from Rabby to the BitBox02 through the bridge was slowed
down, as the BitBox02 aborts after some time of no communication.

An affected user figure dout that the recent hidapi update fixed their
problem. Without knowing exactly what in hidapi might have caused or
fixed the problem, we release this based on the user's experience.

1.5.1 with the updated hidapi lib was released for macOS. Since there
was no change since then, we release the Windows version too as 1.5.1.
