### PR TITLE
windows: fix code signing instructions

### DIFF
--- a/bitbox-bridge/release/README.md
+++ b/bitbox-bridge/release/README.md
@@ -11,7 +11,8 @@ Run `make release`. If needed, run `make dockerinit` to create the docker image.
 Packages (deb/rpm/tar.gz2) will be created without further work.
 
 ## Windows:
-* Install the wix toolset and Visual Studio 2019
+* Install the [wix toolset v3](https://github.com/wixtoolset/wix3/releases/tag/wix3112rtm) (requires
+  .NET 3.5 runtime) and Visual Studio 2019
 * install toml-echo: `cargo install --version 0.3.0 toml-echo`
 * Copy the whole project to a windows machine
 * Modify the path to the signtool in windows/wix/bitboxbridge-codesign.cmd if needed, or put it into

--- a/bitbox-bridge/release/README.md
+++ b/bitbox-bridge/release/README.md
@@ -14,7 +14,8 @@ Packages (deb/rpm/tar.gz2) will be created without further work.
 * Install the wix toolset and Visual Studio 2019
 * install toml-echo: `cargo install --version 0.3.0 toml-echo`
 * Copy the whole project to a windows machine
-* Modify the path to the signtool in windows/wix/signtool.cmd if needed, or put it into `%PATH%`.
+* Modify the path to the signtool in windows/wix/bitboxbridge-codesign.cmd if needed, or put it into
+  `%PATH%`.
 * In the Visual Studio developer command prompt, run `package.cmd` from the windows\wix working directory
 * Find the installer in `./windows/wix/bin/Debug/`.
 

--- a/bitbox-bridge/release/windows/wix/bitboxbridge-codesign.cmd
+++ b/bitbox-bridge/release/windows/wix/bitboxbridge-codesign.cmd
@@ -1,0 +1,1 @@
+bitboxbridge-codesign-impl.cmd %*

--- a/bitbox-bridge/release/windows/wix/bundle.wixproj
+++ b/bitbox-bridge/release/windows/wix/bundle.wixproj
@@ -49,10 +49,10 @@
     <Error Text="The WiX Toolset v3.11 (or newer) build tools must be installed to build this project. To download the WiX Toolset, see http://wixtoolset.org/releases/" />
   </Target>
   <Target Name="SignBundleEngine">
-    <Exec Command="$(ProjectDir)signtool.cmd &quot;@(SignBundleEngine)&quot;" />
+    <Exec Command="$(ProjectDir)bitboxbridge-codesign.cmd &quot;@(SignBundleEngine)&quot;" />
   </Target>
   <Target Name="SignBundle">
-    <Exec Command="$(ProjectDir)signtool.cmd &quot;@(SignBundle)&quot;" />
+    <Exec Command="$(ProjectDir)bitboxbridge-codesign.cmd &quot;@(SignBundle)&quot;" />
   </Target>
   <PropertyGroup>
     <PostBuildEvent />

--- a/bitbox-bridge/release/windows/wix/signtool.cmd
+++ b/bitbox-bridge/release/windows/wix/signtool.cmd
@@ -1,1 +1,0 @@
-shiftcrypto-codesign.cmd %*


### PR DESCRIPTION
The name `signtool.cmd` clashed with the Windows tool of the same name, which could lead to an infinite loop.